### PR TITLE
feat: add basic morph support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
 
       - name: Run Go Tests
         run: go test -coverprofile=coverage.out ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage.out
+coverage.html

--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ seconds on a modest laptop.
 * All relation types (Antonyms, Hyponyms, Hypernyms, etc)
 * Iteration of the database
 * Lemmatization
-
-## Missing features
-
 * Morphology - specifically generating a lemma from input text
 
 ## Example Usage

--- a/data/noun.exc
+++ b/data/noun.exc
@@ -1,0 +1,7 @@
+children child
+geese goose
+noes no
+stamina stamen
+teeth tooth
+theses thesis
+wolves wolf


### PR DESCRIPTION
# Description

This PR will implement a basic support for morph. This code has been heavily inspired by original [wordnet C code](https://wordnet.princeton.edu/documentation/morph3wn).

- Exceptions files (*.exc), containing non-standard plurals, are now parsed and stored in memory
- Morph forms are directly calculated on lookup, the code is basically taking the word, deleting a list of pre-defined suffixes and replacing it with a matching singular form. There are some other specific rules like words finishing with "ful" or "ss".

This first implementation is limited as I wanted to cover most cases already, any help is welcome.