### PR TITLE
chore: fix golang-lint issue

### DIFF
--- a/read.go
+++ b/read.go
@@ -26,6 +26,7 @@ func inPlaceReadLine(s io.Reader, cb func([]byte, int64, int64) error) error {
 		offset += int64(len(line))
 		count++
 	}
+
 	// If we reached end of file and the line contents are empty, don't return an additional line.
 	if err == io.EOF {
 		if len(line) > 0 {
@@ -34,6 +35,7 @@ func inPlaceReadLine(s io.Reader, cb func([]byte, int64, int64) error) error {
 	} else {
 		return cb(line, count, offset)
 	}
+
 	return nil
 }
 
@@ -42,10 +44,12 @@ func inPlaceReadLineFromPath(filePath string, cb func([]byte, int64, int64) erro
 	if err != nil {
 		return err
 	}
+
 	defer func() {
 		if cerr := f.Close(); cerr != nil {
 			fmt.Println("Error closing file:", cerr)
 		}
 	}()
+
 	return inPlaceReadLine(f, cb)
 }

--- a/wordnet.go
+++ b/wordnet.go
@@ -209,6 +209,7 @@ func (w *Lookup) Related(r Relation) (relationships []Lookup) {
 			})
 		}
 	}
+
 	// next let's look for syntactic relationships
 	key := normalize(w.word)
 	for _, word := range w.cluster.words {
@@ -437,10 +438,11 @@ func wordbase(word string, ender int) string {
 
 // Try to find all possible baseforms (lemmas) of individual word in POS.
 func (h *Handle) MorphWord(word string, pos PartOfSpeech) string {
-	if pos == Adverb {
+	switch pos {
+	case Adverb:
 		// Adverbs are not inflected in WordNet
 		return ""
-	} else if pos == Noun {
+	case Noun:
 		if strings.HasSuffix(word, "ful") {
 			return word[:len(word)-3]
 		} else if strings.HasSuffix(word, "ss") || len(word) <= 2 {

--- a/wordnet_test.go
+++ b/wordnet_test.go
@@ -3,6 +3,7 @@ package wnram
 import (
 	"path"
 	"runtime"
+	"slices"
 	"testing"
 )
 
@@ -107,6 +108,7 @@ func TestLemma(t *testing.T) {
 		}
 		t.Fatalf("expected one synonym cluster for awesome, got %d", len(found))
 	}
+
 	if found[0].Lemma() != "amazing" {
 		t.Errorf("incorrect lemma for awesome (%s)", found[0].Lemma())
 	}
@@ -114,13 +116,7 @@ func TestLemma(t *testing.T) {
 
 func setContains(haystack, needles []string) bool {
 	for _, n := range needles {
-		found := false
-		for _, h := range haystack {
-			if n == h {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(haystack, n)
 		if !found {
 			return false
 		}
@@ -160,6 +156,7 @@ func TestAntonyms(t *testing.T) {
 			antonyms = append(antonyms, a.Word())
 		}
 	}
+
 	if !setContains(antonyms, []string{"bad", "evil"}) {
 		t.Errorf("missing antonyms for good")
 	}
@@ -178,6 +175,7 @@ func TestHypernyms(t *testing.T) {
 			hypernyms = append(hypernyms, a.Word())
 		}
 	}
+
 	if !setContains(hypernyms, []string{"punch"}) {
 		t.Errorf("missing hypernyms for jab (expected punch, got %v)", hypernyms)
 	}
@@ -196,6 +194,7 @@ func TestHyponyms(t *testing.T) {
 			hyponyms = append(hyponyms, a.Word())
 		}
 	}
+
 	expected := []string{"chocolate", "cheese", "pasta", "leftovers"}
 	if !setContains(hyponyms, expected) {
 		t.Errorf("missing hyponyms for candy (expected %v, got %v)", expected, hyponyms)
@@ -208,9 +207,11 @@ func TestIterate(t *testing.T) {
 		count++
 		return nil
 	})
+
 	if err != nil {
 		t.Fatalf("Iterate failed: %v", err)
 	}
+
 	if count != 82192 {
 		t.Errorf("Missing nouns!")
 	}


### PR DESCRIPTION
Fix following lint issue :

```golang
wordnet.go:440:2: QF1003: could use tagged switch on pos (staticcheck)
        if pos == Adverb {
        ^
1 issues:
* staticcheck: 1
```

Reformat a bit the code to my own taste